### PR TITLE
Refactored TypedStartEvent behaviour

### DIFF
--- a/docs/md/logic/token_flow_logic_typed_start_events.md
+++ b/docs/md/logic/token_flow_logic_typed_start_events.md
@@ -2,31 +2,26 @@
 @page token_flow_logic_typed_start_events Typed start events
 
 The state of a token at a typed start event is immediately advanced from @ref BPMNOS::Execution::Token::State::ENTERED "ENTERED" to @ref BPMNOS::Execution::Token::State::BUSY "BUSY" and awaits the trigger.
-If the token is at a @ref BPMN::MessageStartEvent "message start event", the @ref BPMNOS::Model::Content "message content" is used to update the @ref BPMNOS::Execution::Token::status "status" of the token. Thereafter, the @ref BPMNOS::Model::ExtensionElements::operators "operators" of the respective event-subprocess are applied.
+If the token is at a @ref BPMN::MessageStartEvent "message start event", the @ref BPMNOS::Model::Content "message content" is used to update the @ref BPMNOS::Execution::Token::status "status" of the token.
 
-After the start event is triggered, the state is advanced @ref BPMNOS::Execution::Token::State::COMPLETED "COMPLETED".
-If the respective @ref BPMN::EventSubProcess "event-subprocesses" is interrupting, all other tokens within the scope of the event-subrocess are withdrawn.
+After the start event is triggered, the @ref BPMNOS::Model::ExtensionElements::operators "operators" of the respective event-subprocess are applied and the state is advanced to @ref BPMNOS::Execution::Token::State::COMPLETED "COMPLETED".
+If the respective @ref BPMN::EventSubProcess "event-subprocesses" is interrupting, all other tokens within the scope of the event-subprocess are withdrawn.
 Otherwise, a new token is created allowing the event-subprocess to be triggered again.
 
 After completion, the entry scope restrictions of the @ref BPMN::EventSubProcess are checked.
 If the restrictions are violated, the state is changed to @ref BPMNOS::Execution::Token::State::FAILED "FAILED".
-Otherwise, the operators of the event-subprocess are applied and the state is changed to @ref BPMNOS::Execution::Token::State::EXITING "EXITING".
-Then, the full scope restrictions of the context are validated and either a failure is raised or the token state is changed to @ref BPMNOS::Execution::Token::State::DEPARTED "DEPARTED" or @ref BPMNOS::Execution::Token::State::DONE "DONE".
+Otherwise, the token state is changed to @ref BPMNOS::Execution::Token::State::DEPARTED "DEPARTED" or @ref BPMNOS::Execution::Token::State::DONE "DONE".
 
 <pre class="mermaid">
 stateDiagram-v2
     state feasibleEntry <<choice>>
-    state feasibleExit <<choice>>
     state departure <<choice>>
     [*] --> ENTERED
     ENTERED --> BUSY
     BUSY --> COMPLETED: trigger
     COMPLETED --> feasibleEntry
-    feasibleEntry --> EXITING: [feasible]
+    feasibleEntry --> departure: [feasible]
     feasibleEntry --> FAILED: [infeasible]
-    EXITING --> feasibleExit
-    feasibleExit --> departure: [feasible]
-    feasibleExit --> FAILED: [infeasible]
     departure --> DEPARTED: [outgoing sequence flow]
     departure --> DONE: [no outgoing sequence flow]
     DEPARTED --> [*]

--- a/execution/controller/src/SeededController.cpp
+++ b/execution/controller/src/SeededController.cpp
@@ -270,7 +270,7 @@ void SeededController::synchronizeSolution(const Token* token) {
     // token at flow node, but with irrelevant state
     return;
   }
-  if ( token->node && token->state != Token::State::EXITING && token->node->represents<BPMN::TypedStartEvent>() ) {
+  if ( token->node && token->state != Token::State::COMPLETED && token->node->represents<BPMN::TypedStartEvent>() ) {
     // token at typed start event, but not triggered
     return;
   }

--- a/execution/engine/src/Token.cpp
+++ b/execution/engine/src/Token.cpp
@@ -735,13 +735,33 @@ void Token::advanceToCompleted() {
   
   if ( node ) {
     // operators of send task, receive task, and decision task are applied on completion
-    if ( 
+    if (
       node->represents<BPMN::ReceiveTask>() ||
-      node->represents<BPMNOS::Model::DecisionTask>() 
+      node->represents<BPMNOS::Model::DecisionTask>()
     ) {
       if ( auto extensionElements = node->extensionElements->represents<BPMNOS::Model::ExtensionElements>() ) {
         if ( !extensionElements->isInstantaneous ) {
           throw std::runtime_error("Token: Operators for task '" + node->id + "' attempt to modify timestamp");
+        }
+        extensionElements->applyOperators(status,*data,globals);
+        // notify about data update
+        if ( extensionElements->dataUpdate.global ) {
+          owner->systemState->engine->notify( DataUpdate( extensionElements->dataUpdate.attributes ) );
+        }
+        else {
+          owner->systemState->engine->notify( DataUpdate( owner->root->instance.value(), extensionElements->dataUpdate.attributes ) );
+        }
+      }
+    }
+    // operators of event subprocesses are applied on completion of typed start event
+    else if ( node->represents<BPMN::TypedStartEvent>() ) {
+      auto eventSubProcess = node->parent->represents<BPMN::EventSubProcess>();
+      if ( !eventSubProcess ) {
+        throw std::runtime_error("Token: typed start event must belong to event subprocess");
+      }
+      if ( auto extensionElements = eventSubProcess->extensionElements->represents<BPMNOS::Model::ExtensionElements>() ) {
+        if ( !extensionElements->isInstantaneous ) {
+          throw std::runtime_error("Token: Operators for event-subprocess '" + eventSubProcess->id + "' attempt to modify timestamp");
         }
         extensionElements->applyOperators(status,*data,globals);
         // notify about data update
@@ -899,8 +919,11 @@ std::cerr << "Context: " << context << " at " << context->scope->id << " has " <
       if ( !extensionElements->feasibleEntry(status,*data,globals) ) {
         engine->commands.emplace_back(std::bind(&Token::advanceToFailed,this), this);
       }
+      else if ( node->outgoing.empty() ) {
+        engine->commands.emplace_back(std::bind(&Token::advanceToDone,this), this);
+      }
       else {
-        engine->commands.emplace_back(std::bind(&Token::advanceToExiting,this), this);
+        advanceToDeparting();
       }
       return;
     }
@@ -931,49 +954,8 @@ void Token::advanceToExiting() {
     throw std::runtime_error("Token: exit timestamp at node '" + node->id + "' is larger than current time");
   }
 
-  if ( node && node->represents<BPMN::TypedStartEvent>() ) {
-    // attribute values of event subprocesses are computed when exiting typed start event  
-    auto eventSubProcess = node->parent->represents<BPMN::EventSubProcess>();
-    if ( !eventSubProcess ) {
-      throw std::runtime_error("Token: typed start event must belong to event subprocess");
-    }
-    if ( auto extensionElements = owner->scope->extensionElements->represents<BPMNOS::Model::ExtensionElements>() ) {
-      if ( !extensionElements->isInstantaneous ) {
-        throw std::runtime_error("Token: Operators for event-subprocess '" + node->parent->id + "' attempt to modify timestamp");
-      }
-      // update status
-      status[BPMNOS::Model::ExtensionElements::Index::Timestamp] = owner->systemState->currentTime;
-      extensionElements->applyOperators(status,*data,globals);
-
-      // notify about data update
-      if ( extensionElements->dataUpdate.global ) {
-        owner->systemState->engine->notify( DataUpdate( extensionElements->dataUpdate.attributes ) );
-      }
-      else {
-        owner->systemState->engine->notify( DataUpdate( owner->root->instance.value(), extensionElements->dataUpdate.attributes ) );
-      }
-    }
-  }
-  
   update(State::EXITING);
 
-  if ( node && node->represents<BPMN::TypedStartEvent>() ) {
-    // check full scope restrictions of event-subprocess
-    auto eventSubProcess = node->parent->represents<BPMN::EventSubProcess>();
-    assert(eventSubProcess);
-//std::cerr << "check full scope restrictions of event-subprocess" << std::endl;
-    if ( !eventSubProcess->extensionElements->as<BPMNOS::Model::ExtensionElements>()->fullScopeRestrictionsSatisfied(status,*data,globals) ) {
-      engine->commands.emplace_back(std::bind(&Token::advanceToFailed,this), this);
-    }
-    else if ( node->outgoing.empty() ) {
-      engine->commands.emplace_back(std::bind(&Token::advanceToDone,this), this);
-    }
-    else {
-      advanceToDeparting();
-    }
-    return;
-  }
-  
   // check restrictions
   if ( !exitIsFeasible() ) {
     engine->commands.emplace_back(std::bind(&Token::advanceToFailed,this), this);

--- a/execution/observer/src/CPSolutionObserver.cpp
+++ b/execution/observer/src/CPSolutionObserver.cpp
@@ -116,8 +116,7 @@ void CPSolutionObserver::synchronize(const Token* token) {
 
     // event-subprocess is triggered
     _solution.setVariableValue( cp->visit.at(vertex), true );
-    // for typed start events data and globals remain unchanged upon completion
-    // operators of event-subprocess are applied after completion
+    // for typed start events, operators of event-subprocess are applied before completion
     synchronizeData(*token->data,entry(vertex));
     synchronizeGlobals(token->globals,entry(vertex));
   }

--- a/tests/execution/eventsubprocess/test.h
+++ b/tests/execution/eventsubprocess/test.h
@@ -37,8 +37,7 @@ SCENARIO( "Caught error end event", "[execution][eventsubprocess]" ) {
         REQUIRE( errorStartEventLog[0]["state"] == "ENTERED" );
         REQUIRE( errorStartEventLog[1]["state"] == "BUSY" );
         REQUIRE( errorStartEventLog[2]["state"] == "COMPLETED" );
-        REQUIRE( errorStartEventLog[3]["state"] == "EXITING" );
-        REQUIRE( errorStartEventLog[4]["state"] == "DONE" );
+        REQUIRE( errorStartEventLog[3]["state"] == "DONE" );
 
         auto errorEndEventLog = recorder.find(nlohmann::json{{"nodeId","ErrorEndEvent_1" }}, nlohmann::json{{"event",nullptr },{"decision",nullptr }});
         REQUIRE( errorEndEventLog[0]["state"] == "ARRIVED" );
@@ -96,8 +95,7 @@ SCENARIO( "Interrupting escalation", "[execution][eventsubprocess]" ) {
         REQUIRE( escalationStartEventLog[1]["state"] == "BUSY" );
         REQUIRE( escalationStartEventLog[2]["status"]["timestamp"] == 1.0);
         REQUIRE( escalationStartEventLog[2]["state"] == "COMPLETED" );
-        REQUIRE( escalationStartEventLog[3]["state"] == "EXITING" );
-        REQUIRE( escalationStartEventLog[4]["state"] == "DONE" );
+        REQUIRE( escalationStartEventLog[3]["state"] == "DONE" );
 
         auto escalationEventLog = recorder.find(nlohmann::json{{"nodeId","EscalationEvent_1" }}, nlohmann::json{{"event",nullptr },{"decision",nullptr }});
         REQUIRE( escalationEventLog[0]["state"] == "ARRIVED" );
@@ -231,8 +229,7 @@ SCENARIO( "Caught and rethrown error", "[execution][eventsubprocess]" ) {
         REQUIRE( errorStartEventLog[0]["state"] == "ENTERED" );
         REQUIRE( errorStartEventLog[1]["state"] == "BUSY" );
         REQUIRE( errorStartEventLog[2]["state"] == "COMPLETED" );
-        REQUIRE( errorStartEventLog[3]["state"] == "EXITING" );
-        REQUIRE( errorStartEventLog[4]["state"] == "DEPARTED" );
+        REQUIRE( errorStartEventLog[3]["state"] == "DEPARTED" );
 
         auto errorEndEvent1Log = recorder.find(nlohmann::json{{"nodeId","ErrorEndEvent_1" }}, nlohmann::json{{"event",nullptr },{"decision",nullptr }});
         REQUIRE( errorEndEvent1Log[0]["state"] == "ARRIVED" );
@@ -349,8 +346,7 @@ SCENARIO( "Interrupting escalation throwing error", "[execution][eventsubprocess
         REQUIRE( escalationStartEventLog1[1]["state"] == "BUSY" );
         REQUIRE( escalationStartEventLog1[2]["status"]["timestamp"] == 0.0);
         REQUIRE( escalationStartEventLog1[2]["state"] == "COMPLETED" );
-        REQUIRE( escalationStartEventLog1[3]["state"] == "EXITING" );
-        REQUIRE( escalationStartEventLog1[4]["state"] == "DEPARTED" );
+        REQUIRE( escalationStartEventLog1[3]["state"] == "DEPARTED" );
 
         auto errorEndEventLog = recorder.find(nlohmann::json{{"nodeId","ErrorEndEvent_2" }}, nlohmann::json{{"event",nullptr },{"decision",nullptr }});
         REQUIRE( errorEndEventLog[0]["state"] == "ARRIVED" );


### PR DESCRIPTION
`TypedStartEvent` apply operators before state `COMPLETED` and check restrictions thereafter. State `EXITING` is no longer a valid state for `TypedStartEvent`.