### PR TITLE
Add StochasticScenario copy constructor with resampling

### DIFF
--- a/model/data/src/Scenario.cpp
+++ b/model/data/src/Scenario.cpp
@@ -10,6 +10,14 @@ Scenario::Scenario(const Model* model, const std::unordered_map<const Attribute*
 {
 }
 
+Scenario::Scenario(const Scenario* original)
+  : model(original->model)
+  , globals(original->globals)
+  , taskCompletionStatus(original->taskCompletionStatus)
+  , activityArrivalStatus(original->activityArrivalStatus)
+{
+}
+
 BPMNOS::Values Scenario::evaluateGlobals(const std::unordered_map<const Attribute*, BPMNOS::number>& globalValueMap) {
   Values result(model->attributes.size());
 

--- a/model/data/src/Scenario.h
+++ b/model/data/src/Scenario.h
@@ -157,6 +157,9 @@ protected:
   /// Constructor that initializes model and globals from CSV-provided values.
   Scenario(const Model* model, const std::unordered_map<const Attribute*, BPMNOS::number>& globalValueMap);
 
+  /// Protected copy constructor for derived class scenario copying.
+  Scenario(const Scenario* original);
+
   /// Evaluate global attributes (CSV-provided + model expressions).
   Values evaluateGlobals(const std::unordered_map<const Attribute*, BPMNOS::number>& globalValueMap);
 

--- a/model/data/src/StochasticDataProvider.cpp
+++ b/model/data/src/StochasticDataProvider.cpp
@@ -157,7 +157,7 @@ void StochasticDataProvider::readInstances() {
         }
 
         auto extensionElements = node->extensionElements->as<BPMNOS::Model::ExtensionElements>();
-        auto expression = std::make_unique<Expression>(stochasticHandle, completionExpression,
+        auto expression = std::make_shared<Expression>(stochasticHandle, completionExpression,
                                                        extensionElements->attributeRegistry);
 
         // Completion expressions must only modify STATUS attributes
@@ -185,7 +185,7 @@ void StochasticDataProvider::readInstances() {
         }
 
         auto extensionElements = node->extensionElements->as<BPMNOS::Model::ExtensionElements>();
-        auto expression = std::make_unique<Expression>(stochasticHandle, readyExpression, extensionElements->attributeRegistry);
+        auto expression = std::make_shared<Expression>(stochasticHandle, readyExpression, extensionElements->attributeRegistry);
 
         // Ready expressions must only modify STATUS attributes
         if (expression->target.has_value() &&
@@ -205,11 +205,16 @@ void StochasticDataProvider::readInstances() {
       }
       else {
         auto [attribute, expressionString] = lookupAttribute(node, initializationString);
+        auto extensionElements = node->extensionElements->as<BPMNOS::Model::ExtensionElements>();
 
-        // All initializations are deferred for per-scenario evaluation
+        // Create shared expressions for per-scenario evaluation
+        auto initializationExpression = std::make_shared<Expression>(stochasticHandle, expressionString, extensionElements->attributeRegistry);
+
         // If no DISCLOSURE expression, default to disclosure at time 0
-        std::string disclosure = disclosureExpression.empty() ? "0" : disclosureExpression;
-        deferredAttributes[instanceId].push_back({attribute, node, expressionString, disclosure});
+        std::string disclosureString = disclosureExpression.empty() ? "0" : disclosureExpression;
+        auto disclosureExpressionPtr = std::make_shared<Expression>(stochasticHandle, disclosureString, extensionElements->attributeRegistry);
+
+        deferredAttributes[instanceId].push_back({attribute, node, initializationExpression, disclosureExpressionPtr});
       }
     }
   }
@@ -283,40 +288,30 @@ std::unique_ptr<Scenario> StochasticDataProvider::createScenario(unsigned int sc
     }
   }
 
-  // Add deferred disclosures (to be evaluated per-scenario)
+  // Add deferred disclosures (shared expressions, evaluated per-scenario with different RNG)
   for (auto& [instanceId, deferreds] : deferredAttributes) {
     for (auto& deferred : deferreds) {
       scenario->addDeferredDisclosure(
-        instanceId, 
+        instanceId,
         {deferred.attribute, deferred.node, deferred.initializationExpression, deferred.disclosureExpression}
       );
     }
   }
 
-  // Add completion expressions
+  // Share completion expressions
   for (auto& [instanceId, tasks] : completionExpressions) {
     for (auto& [task, expressions] : tasks) {
-      for (auto& sourceExpression : expressions) {
-        auto expression = std::make_unique<Expression>(
-          stochasticHandle,
-          sourceExpression->expression,
-          sourceExpression->attributeRegistry
-        );
-        scenario->addCompletionExpression(instanceId, task, std::move(expression));
+      for (auto& expression : expressions) {
+        scenario->addCompletionExpression(instanceId, task, expression);
       }
     }
   }
 
-  // Add ready expressions
+  // Share ready expressions
   for (auto& [instanceId, nodes] : readyExpressions) {
     for (auto& [node, expressions] : nodes) {
-      for (auto& sourceExpression : expressions) {
-        auto expression = std::make_unique<Expression>(
-          stochasticHandle,
-          sourceExpression->expression,
-          sourceExpression->attributeRegistry
-        );
-        scenario->addReadyExpression(instanceId, node, std::move(expression));
+      for (auto& expression : expressions) {
+        scenario->addReadyExpression(instanceId, node, expression);
       }
     }
   }

--- a/model/data/src/StochasticDataProvider.cpp
+++ b/model/data/src/StochasticDataProvider.cpp
@@ -92,10 +92,12 @@ void StochasticDataProvider::readInstances() {
     // Get disclosure (if 4+ columns)
     std::string disclosureExpression;
     if (columnCount >= 4) {
-      if (!std::holds_alternative<std::string>(row.at(DISCLOSURE))) {
-        throw std::runtime_error("StochasticDataProvider: illegal disclosure");
+      if (std::holds_alternative<std::string>(row.at(DISCLOSURE))) {
+        disclosureExpression = std::get<std::string>(row.at(DISCLOSURE));
       }
-      disclosureExpression = std::get<std::string>(row.at(DISCLOSURE));
+      else if (std::holds_alternative<BPMNOS::number>(row.at(DISCLOSURE))) {
+        disclosureExpression = std::to_string((double)std::get<BPMNOS::number>(row.at(DISCLOSURE)));
+      }
     }
 
     // Get ready (if 6 columns)

--- a/model/data/src/StochasticDataProvider.cpp
+++ b/model/data/src/StochasticDataProvider.cpp
@@ -147,7 +147,7 @@ void StochasticDataProvider::readInstances() {
         auto process = dynamic_cast<BPMN::Process*>(node);
         instances[instanceId] = StochasticInstanceData{process, instanceId,
                                                        std::numeric_limits<BPMNOS::number>::max(), {}};
-        disclosure[instanceId][process] = 0;
+        disclosureTimes[instanceId][process] = 0;
       }
 
       // Handle COMPLETION expression (valid for all Task types)
@@ -251,17 +251,17 @@ BPMNOS::number StochasticDataProvider::getEffectiveDisclosure(size_t instanceId,
 
   if (auto childNode = node->represents<BPMN::ChildNode>()) {
     auto parentNode = childNode->parent;
-    if (!disclosure[instanceId].contains(parentNode)) {
+    if (!disclosureTimes[instanceId].contains(parentNode)) {
       throw std::runtime_error("StochasticDataProvider: disclosure for '" + node->id + "' given before parent '" + parentNode->id + "'");
     }
-    effectiveDisclosure = std::max(effectiveDisclosure, disclosure[instanceId][parentNode]);
+    effectiveDisclosure = std::max(effectiveDisclosure, disclosureTimes[instanceId][parentNode]);
   }
 
-  if (!disclosure[instanceId].contains(node)) {
-    disclosure[instanceId][node] = effectiveDisclosure;
+  if (!disclosureTimes[instanceId].contains(node)) {
+    disclosureTimes[instanceId][node] = effectiveDisclosure;
   }
   else {
-    disclosure[instanceId][node] = std::max(disclosure[instanceId][node], effectiveDisclosure);
+    disclosureTimes[instanceId][node] = std::max(disclosureTimes[instanceId][node], effectiveDisclosure);
   }
 
   return effectiveDisclosure;
@@ -282,7 +282,7 @@ std::unique_ptr<Scenario> StochasticDataProvider::createScenario(unsigned int sc
   }
 
   // Set node disclosure times (from immediate disclosures)
-  for (auto& [instanceId, nodes] : disclosure) {
+  for (auto& [instanceId, nodes] : disclosureTimes) {
     for (auto& [node, disclosureTime] : nodes) {
       scenario->setDisclosure(instanceId, node, disclosureTime);
     }

--- a/model/data/src/StochasticDataProvider.h
+++ b/model/data/src/StochasticDataProvider.h
@@ -19,9 +19,17 @@ namespace BPMNOS::Model {
  * StochasticDataProvider supports:
  * - 3-column format (INSTANCE_ID, NODE_ID, INITIALIZATION) - static behavior
  * - 4-column format (+ DISCLOSURE) - dynamic behavior
- * - 6-column format (+ ARRIVAL, COMPLETION) - stochastic behavior
+ * - 6-column format (+ READY, COMPLETION) - stochastic behavior
  *
  * Has its own LIMEX handle with lookup tables from Model plus random functions.
+ *
+ * @note CSV ordering: For dependent expressions, parent node rows must be listed
+ *       before child node rows in the CSV file. If a child expression depends on
+ *       a parent's deferred attribute, the parent must be evaluated first.
+ *
+ * @note Guidance constraint: Guidance expressions must only reference attributes
+ *       that are disclosed at the time of access. This is not enforced; it is
+ *       the user's responsibility to ensure correct usage.
  */
 class StochasticDataProvider : public DataProvider {
 public:

--- a/model/data/src/StochasticDataProvider.h
+++ b/model/data/src/StochasticDataProvider.h
@@ -77,7 +77,7 @@ protected:
   std::unordered_map<size_t, std::unordered_map<const BPMN::Node*, std::vector<std::shared_ptr<Expression>>>> completionExpressions;
 
   /// Node disclosure times
-  std::unordered_map<size_t, std::unordered_map<const BPMN::Node*, BPMNOS::number>> disclosure;
+  std::unordered_map<size_t, std::unordered_map<const BPMN::Node*, BPMNOS::number>> disclosureTimes;
 
   BPMNOS::number evaluateExpression(const std::string& expressionString) const override;
   BPMNOS::number evaluateExpression(size_t instanceId, const BPMN::Node* node,

--- a/model/data/src/StochasticDataProvider.h
+++ b/model/data/src/StochasticDataProvider.h
@@ -61,8 +61,8 @@ protected:
   struct DeferredAttribute {
     const Attribute* attribute;
     const BPMN::Node* node;
-    std::string initializationExpression;
-    std::string disclosureExpression;
+    std::shared_ptr<Expression> initializationExpression;
+    std::shared_ptr<Expression> disclosureExpression;
   };
 
   std::unordered_map<long unsigned int, StochasticInstanceData> instances;
@@ -70,11 +70,11 @@ protected:
   /// Deferred attributes (evaluated per-scenario)
   std::unordered_map<size_t, std::vector<DeferredAttribute>> deferredAttributes;
 
-  /// Ready expressions per (instance, node)
-  std::unordered_map<size_t, std::unordered_map<const BPMN::Node*, std::vector<std::unique_ptr<Expression>>>> readyExpressions;
+  /// Ready expressions per (instance, node) - shared with scenarios
+  std::unordered_map<size_t, std::unordered_map<const BPMN::Node*, std::vector<std::shared_ptr<Expression>>>> readyExpressions;
 
-  /// Completion expressions per (instance, node)
-  std::unordered_map<size_t, std::unordered_map<const BPMN::Node*, std::vector<std::unique_ptr<Expression>>>> completionExpressions;
+  /// Completion expressions per (instance, node) - shared with scenarios
+  std::unordered_map<size_t, std::unordered_map<const BPMN::Node*, std::vector<std::shared_ptr<Expression>>>> completionExpressions;
 
   /// Node disclosure times
   std::unordered_map<size_t, std::unordered_map<const BPMN::Node*, BPMNOS::number>> disclosure;

--- a/model/data/src/StochasticScenario.cpp
+++ b/model/data/src/StochasticScenario.cpp
@@ -3,6 +3,7 @@
 #include "model/bpmnos/src/extensionElements/ExtensionElements.h"
 #include <cmath>
 #include <functional>
+#include <stdexcept>
 
 using namespace BPMNOS::Model;
 
@@ -16,6 +17,28 @@ StochasticScenario::StochasticScenario(
   , earliestInstantiationTime(std::numeric_limits<BPMNOS::number>::infinity())
   , latestInstantiationTime(std::numeric_limits<BPMNOS::number>::lowest())
 {
+}
+
+StochasticScenario::StochasticScenario(StochasticScenario* original, BPMNOS::number spawnTime, unsigned int seed)
+  : Scenario(original)
+  , instances(original->instances)
+  , disclosureTimes(original->disclosureTimes)
+  , pastDisclosures(original->pastDisclosures)
+  , pendingDisclosures(original->pendingDisclosures)
+  , readyExpressions(original->readyExpressions)
+  , completionExpressions(original->completionExpressions)
+  , deferredDisclosures(original->deferredDisclosures)
+  , scenarioSeeds(original->scenarioSeeds)
+  , earliestInstantiationTime(original->earliestInstantiationTime)
+  , latestInstantiationTime(original->latestInstantiationTime)
+  , randomFactory(original->randomFactory)
+  , stochasticHandle(original->stochasticHandle)
+{
+  // Append new seed (rngs not copied - recreated with new seed via getRng())
+  scenarioSeeds.push_back({spawnTime, seed});
+
+  // Resample future items (validates precondition and throws if violated)
+  evaluateDeferredDisclosures(spawnTime);
 }
 
 void StochasticScenario::addInstance(const BPMN::Process* process, const BPMNOS::number instanceId) {
@@ -56,11 +79,22 @@ void StochasticScenario::evaluateDeferredDisclosures(BPMNOS::number spawnTime) {
     auto& instance = instances.at(instanceId);
 
     for (auto& disclosure : disclosures) {
-      // Skip if already evaluated and disclosureTime < spawnTime
+      // Skip if already revealed (in pastDisclosures)
+      if (pastDisclosures.contains(instanceId) &&
+          pastDisclosures.at(instanceId).contains(disclosure.attribute)
+      ) {
+        if (pastDisclosures.at(instanceId).at(disclosure.attribute).disclosureTime >= spawnTime) {
+          throw std::logic_error("StochasticScenario: past disclosure for '" + disclosure.attribute->name + "' has disclosureTime >= spawnTime");
+        }
+        continue;
+      }
+
+      // Check if already evaluated with disclosureTime < spawnTime (precondition violation)
       if (pendingDisclosures.contains(instanceId) &&
           pendingDisclosures.at(instanceId).contains(disclosure.attribute) &&
-          pendingDisclosures.at(instanceId).at(disclosure.attribute).disclosureTime < spawnTime) {
-        continue;
+          pendingDisclosures.at(instanceId).at(disclosure.attribute).disclosureTime < spawnTime
+      ) {
+        throw std::logic_error("StochasticScenario: pending disclosure for '" + disclosure.attribute->name + "' has disclosureTime < spawnTime");
       }
 
       // Set RNG context for this (instance, node)

--- a/model/data/src/StochasticScenario.cpp
+++ b/model/data/src/StochasticScenario.cpp
@@ -12,7 +12,7 @@ StochasticScenario::StochasticScenario(
   unsigned int seed
 )
   : Scenario(model, globalValueMap)
-  , scenarioSeed(seed)
+  , scenarioSeeds({{0, seed}})
   , earliestInstantiationTime(std::numeric_limits<BPMNOS::number>::infinity())
   , latestInstantiationTime(std::numeric_limits<BPMNOS::number>::lowest())
 {
@@ -232,9 +232,10 @@ void StochasticScenario::initializeActivityData(BPMNOS::number instanceId, const
 std::mt19937& StochasticScenario::getRng(size_t instanceId, const BPMN::Node* node) const {
   auto key = std::make_pair(instanceId, node);
   if (!rngs.contains(key)) {
-    // Create RNG seeded from scenarioSeed combined with instanceId and node hash
+    // Create RNG seeded from current seed combined with instanceId and node hash
+    unsigned int currentSeed = scenarioSeeds.back().second;
     size_t nodeHash = std::hash<std::string>{}(node->id);
-    size_t combinedSeed = static_cast<size_t>(scenarioSeed) ^ (instanceId * 31) ^ (nodeHash * 17);
+    size_t combinedSeed = static_cast<size_t>(currentSeed) ^ (instanceId * 31) ^ (nodeHash * 17);
     rngs[key] = std::mt19937(combinedSeed);
   }
   return rngs[key];

--- a/model/data/src/StochasticScenario.cpp
+++ b/model/data/src/StochasticScenario.cpp
@@ -101,9 +101,6 @@ void StochasticScenario::evaluateDeferredDisclosures(BPMNOS::number spawnTime) {
           break;
       }
 
-      // Store value
-      instance.values[deferred->attribute] = value;
-
       // Update instantiation time if timestamp
       if (deferred->attribute->id == Keyword::Timestamp) {
         instance.instantiationTime = BPMNOS::number(std::ceil((double)value));
@@ -173,9 +170,6 @@ void StochasticScenario::evaluateDeferredDisclosures(BPMNOS::number spawnTime) {
         default:
           break;
       }
-
-      // Store value
-      instance.values[disclosure.attribute] = value;
 
       // Update instantiation time if timestamp
       if (disclosure.attribute->id == Keyword::Timestamp) {

--- a/model/data/src/StochasticScenario.cpp
+++ b/model/data/src/StochasticScenario.cpp
@@ -35,11 +35,11 @@ void StochasticScenario::addPendingDisclosure(const BPMNOS::number instanceId, S
   pendingDisclosures[(size_t)instanceId].push_back(std::move(pending));
 }
 
-void StochasticScenario::addCompletionExpression(const BPMNOS::number instanceId, const BPMN::Node* task, std::unique_ptr<Expression> expression) {
+void StochasticScenario::addCompletionExpression(const BPMNOS::number instanceId, const BPMN::Node* task, std::shared_ptr<Expression> expression) {
   completionExpressions[(size_t)instanceId][task].push_back(std::move(expression));
 }
 
-void StochasticScenario::addReadyExpression(const BPMNOS::number instanceId, const BPMN::Node* node, std::unique_ptr<Expression> expression) {
+void StochasticScenario::addReadyExpression(const BPMNOS::number instanceId, const BPMN::Node* node, std::shared_ptr<Expression> expression) {
   readyExpressions[(size_t)instanceId][node].push_back(std::move(expression));
 }
 
@@ -70,9 +70,8 @@ void StochasticScenario::evaluateDeferredDisclosures() {
         data.push_back(instance.values.contains(attr.get()) ? instance.values.at(attr.get()) : std::nullopt);
       }
 
-      // Evaluate initialization expression
-      Expression initializationExpression(*stochasticHandle, deferred.initializationExpression, extensionElements->attributeRegistry);
-      BPMNOS::number value = initializationExpression.execute(status, data, globals).value_or(0);
+      // Evaluate initialization expression (shared, different results from RNG context)
+      BPMNOS::number value = deferred.initializationExpression->execute(status, data, globals).value_or(0);
 
       // Apply type conversion
       switch (deferred.attribute->type) {
@@ -94,9 +93,8 @@ void StochasticScenario::evaluateDeferredDisclosures() {
         instance.instantiationTime = BPMNOS::number(std::ceil((double)value));
       }
 
-      // Evaluate disclosure expression
-      Expression disclosureExpression(*stochasticHandle, deferred.disclosureExpression, extensionElements->attributeRegistry);
-      BPMNOS::number ownDisclosure = BPMNOS::number(std::ceil((double)disclosureExpression.execute(status, data, globals).value_or(0)));
+      // Evaluate disclosure expression (shared, different results from RNG context)
+      BPMNOS::number ownDisclosure = BPMNOS::number(std::ceil((double)deferred.disclosureExpression->execute(status, data, globals).value_or(0)));
       // Compute effective disclosure (max with parent scope)
       BPMNOS::number effectiveDisclosure = ownDisclosure;
       if (auto childNode = deferred.node->represents<BPMN::ChildNode>()) {

--- a/model/data/src/StochasticScenario.cpp
+++ b/model/data/src/StochasticScenario.cpp
@@ -52,93 +52,14 @@ void StochasticScenario::evaluateDeferredDisclosures(BPMNOS::number spawnTime) {
     return;
   }
 
-  // Build map from attribute to deferred for O(1) lookup
-  std::unordered_map<size_t, std::unordered_map<const Attribute*, const DeferredDisclosure*>> deferredByAttribute;
-  for (auto& [instanceId, disclosures] : deferredDisclosures) {
-    for (auto& disclosure : disclosures) {
-      deferredByAttribute[instanceId][disclosure.attribute] = &disclosure;
-    }
-  }
-
-  // Re-evaluate pending disclosures with disclosureTime >= spawnTime
-  for (auto& [instanceId, disclosures] : pendingDisclosures) {
-    auto& instance = instances.at(instanceId);
-
-    for (auto& [attribute, pending] : disclosures) {
-      if (pending.disclosureTime < spawnTime) {
-        continue;  // Skip past disclosures
-      }
-
-      // Find corresponding deferred
-      auto* deferred = deferredByAttribute[instanceId][attribute];
-
-      // Set RNG context for this (instance, node)
-      auto& rng = getRng(instanceId, deferred->node);
-      randomFactory->setCurrentRng(&rng);
-
-      // Build status/data vectors from instance values
-      auto extensionElements = deferred->node->extensionElements->as<const ExtensionElements>();
-      Values status, data;
-      for (auto& attr : extensionElements->attributes) {
-        status.push_back(instance.values.contains(attr.get()) ? instance.values.at(attr.get()) : std::nullopt);
-      }
-      for (auto& attr : extensionElements->data) {
-        data.push_back(instance.values.contains(attr.get()) ? instance.values.at(attr.get()) : std::nullopt);
-      }
-
-      // Evaluate initialization expression
-      BPMNOS::number value = deferred->initializationExpression->execute(status, data, globals).value_or(0);
-
-      // Apply type conversion
-      switch (deferred->attribute->type) {
-        case ValueType::INTEGER:
-          value = BPMNOS::number((int)value);
-          break;
-        case ValueType::BOOLEAN:
-          value = BPMNOS::number(value != 0 ? 1 : 0);
-          break;
-        default:
-          break;
-      }
-
-      // Update instantiation time if timestamp
-      if (deferred->attribute->id == Keyword::Timestamp) {
-        instance.instantiationTime = BPMNOS::number(std::ceil((double)value));
-      }
-
-      // Evaluate disclosure expression
-      BPMNOS::number disclosureTime = BPMNOS::number(std::ceil((double)deferred->disclosureExpression->execute(status, data, globals).value_or(0)));
-
-      // Compute effective disclosure time (max with parent scope)
-      BPMNOS::number effectiveDisclosureTime = disclosureTime;
-      if (auto childNode = deferred->node->represents<BPMN::ChildNode>()) {
-        auto parentNode = childNode->parent;
-        if (disclosureTimes.contains(instanceId) && disclosureTimes.at(instanceId).contains(parentNode)) {
-          effectiveDisclosureTime = std::max(effectiveDisclosureTime, disclosureTimes.at(instanceId).at(parentNode));
-        }
-      }
-
-      // Update node disclosure time
-      if (!disclosureTimes[instanceId].contains(deferred->node)) {
-        disclosureTimes[instanceId][deferred->node] = effectiveDisclosureTime;
-      }
-      else {
-        disclosureTimes[instanceId][deferred->node] = std::max(disclosureTimes[instanceId][deferred->node], effectiveDisclosureTime);
-      }
-
-      // Update pending disclosure
-      pending = {deferred->attribute, disclosureTime, value};
-    }
-  }
-
-  // Initial evaluation: process disclosures not yet in pendingDisclosures
   for (auto& [instanceId, disclosures] : deferredDisclosures) {
     auto& instance = instances.at(instanceId);
 
     for (auto& disclosure : disclosures) {
-      // Skip if already in pendingDisclosures
+      // Skip if already evaluated and disclosureTime < spawnTime
       if (pendingDisclosures.contains(instanceId) &&
-          pendingDisclosures.at(instanceId).contains(disclosure.attribute)) {
+          pendingDisclosures.at(instanceId).contains(disclosure.attribute) &&
+          pendingDisclosures.at(instanceId).at(disclosure.attribute).disclosureTime < spawnTime) {
         continue;
       }
 
@@ -171,13 +92,36 @@ void StochasticScenario::evaluateDeferredDisclosures(BPMNOS::number spawnTime) {
           break;
       }
 
-      // Update instantiation time if timestamp
+      // Resample timestamp if before spawnTime
       if (disclosure.attribute->id == Keyword::Timestamp) {
+        for (int tries = 1; value < spawnTime && tries < maxResamplingTries; ++tries) {
+          value = disclosure.initializationExpression->execute(status, data, globals).value_or(0);
+          value = BPMNOS::number((int)value);  // Timestamp is INTEGER type
+        }
+
+        // Fall back to spawnTime if still in the past
+        if (value < spawnTime) {
+          value = spawnTime;
+        }
+
         instance.instantiationTime = BPMNOS::number(std::ceil((double)value));
       }
 
-      // Evaluate disclosure expression
+      // Store value for dependent attributes
+      instance.values[disclosure.attribute] = value;
+
+      // Evaluate disclosure expression with resampling if needed
       BPMNOS::number disclosureTime = BPMNOS::number(std::ceil((double)disclosure.disclosureExpression->execute(status, data, globals).value_or(0)));
+
+      // Resample if disclosure time is before spawnTime
+      for (int tries = 1; disclosureTime < spawnTime && tries < maxResamplingTries; ++tries) {
+        disclosureTime = BPMNOS::number(std::ceil((double)disclosure.disclosureExpression->execute(status, data, globals).value_or(0)));
+      }
+
+      // Fall back to spawnTime if still in the past
+      if (disclosureTime < spawnTime) {
+        disclosureTime = spawnTime;
+      }
 
       // Compute effective disclosure time (max with parent scope)
       BPMNOS::number effectiveDisclosureTime = disclosureTime;
@@ -196,7 +140,7 @@ void StochasticScenario::evaluateDeferredDisclosures(BPMNOS::number spawnTime) {
         disclosureTimes[instanceId][disclosure.node] = std::max(disclosureTimes[instanceId][disclosure.node], effectiveDisclosureTime);
       }
 
-      // Add as pending disclosure
+      // Store in pending disclosures
       pendingDisclosures[instanceId][disclosure.attribute] = {disclosure.attribute, disclosureTime, value};
     }
   }
@@ -490,14 +434,10 @@ void StochasticScenario::setTaskCompletionStatus(BPMNOS::number instanceId, cons
 
 void StochasticScenario::revealData(BPMNOS::number currentTime) const {
   for (auto& [instanceId, disclosures] : pendingDisclosures) {
-    auto& instance = instances.at(instanceId);
-
     // Process pending disclosures that are due
     for (auto it = disclosures.begin(); it != disclosures.end(); ) {
       auto& [attribute, disclosure] = *it;
       if (currentTime >= disclosure.disclosureTime) {
-        // Reveal pre-computed value
-        instance.values[attribute] = disclosure.value;
         // Move to past disclosures
         pastDisclosures[instanceId][attribute] = std::move(disclosure);
         it = disclosures.erase(it);

--- a/model/data/src/StochasticScenario.cpp
+++ b/model/data/src/StochasticScenario.cpp
@@ -107,27 +107,27 @@ void StochasticScenario::evaluateDeferredDisclosures(BPMNOS::number spawnTime) {
       }
 
       // Evaluate disclosure expression
-      BPMNOS::number ownDisclosure = BPMNOS::number(std::ceil((double)deferred->disclosureExpression->execute(status, data, globals).value_or(0)));
+      BPMNOS::number disclosureTime = BPMNOS::number(std::ceil((double)deferred->disclosureExpression->execute(status, data, globals).value_or(0)));
 
-      // Compute effective disclosure (max with parent scope)
-      BPMNOS::number effectiveDisclosure = ownDisclosure;
+      // Compute effective disclosure time (max with parent scope)
+      BPMNOS::number effectiveDisclosureTime = disclosureTime;
       if (auto childNode = deferred->node->represents<BPMN::ChildNode>()) {
         auto parentNode = childNode->parent;
         if (disclosureTimes.contains(instanceId) && disclosureTimes.at(instanceId).contains(parentNode)) {
-          effectiveDisclosure = std::max(effectiveDisclosure, disclosureTimes.at(instanceId).at(parentNode));
+          effectiveDisclosureTime = std::max(effectiveDisclosureTime, disclosureTimes.at(instanceId).at(parentNode));
         }
       }
 
       // Update node disclosure time
       if (!disclosureTimes[instanceId].contains(deferred->node)) {
-        disclosureTimes[instanceId][deferred->node] = effectiveDisclosure;
+        disclosureTimes[instanceId][deferred->node] = effectiveDisclosureTime;
       }
       else {
-        disclosureTimes[instanceId][deferred->node] = std::max(disclosureTimes[instanceId][deferred->node], effectiveDisclosure);
+        disclosureTimes[instanceId][deferred->node] = std::max(disclosureTimes[instanceId][deferred->node], effectiveDisclosureTime);
       }
 
       // Update pending disclosure
-      pending = {deferred->attribute, ownDisclosure, effectiveDisclosure, value};
+      pending = {deferred->attribute, disclosureTime, value};
     }
   }
 
@@ -177,27 +177,27 @@ void StochasticScenario::evaluateDeferredDisclosures(BPMNOS::number spawnTime) {
       }
 
       // Evaluate disclosure expression
-      BPMNOS::number ownDisclosure = BPMNOS::number(std::ceil((double)disclosure.disclosureExpression->execute(status, data, globals).value_or(0)));
+      BPMNOS::number disclosureTime = BPMNOS::number(std::ceil((double)disclosure.disclosureExpression->execute(status, data, globals).value_or(0)));
 
-      // Compute effective disclosure (max with parent scope)
-      BPMNOS::number effectiveDisclosure = ownDisclosure;
+      // Compute effective disclosure time (max with parent scope)
+      BPMNOS::number effectiveDisclosureTime = disclosureTime;
       if (auto childNode = disclosure.node->represents<BPMN::ChildNode>()) {
         auto parentNode = childNode->parent;
         if (disclosureTimes.contains(instanceId) && disclosureTimes.at(instanceId).contains(parentNode)) {
-          effectiveDisclosure = std::max(effectiveDisclosure, disclosureTimes.at(instanceId).at(parentNode));
+          effectiveDisclosureTime = std::max(effectiveDisclosureTime, disclosureTimes.at(instanceId).at(parentNode));
         }
       }
 
       // Update node disclosure time
       if (!disclosureTimes[instanceId].contains(disclosure.node)) {
-        disclosureTimes[instanceId][disclosure.node] = effectiveDisclosure;
+        disclosureTimes[instanceId][disclosure.node] = effectiveDisclosureTime;
       }
       else {
-        disclosureTimes[instanceId][disclosure.node] = std::max(disclosureTimes[instanceId][disclosure.node], effectiveDisclosure);
+        disclosureTimes[instanceId][disclosure.node] = std::max(disclosureTimes[instanceId][disclosure.node], effectiveDisclosureTime);
       }
 
       // Add as pending disclosure
-      pendingDisclosures[instanceId][disclosure.attribute] = {disclosure.attribute, ownDisclosure, effectiveDisclosure, value};
+      pendingDisclosures[instanceId][disclosure.attribute] = {disclosure.attribute, disclosureTime, value};
     }
   }
 
@@ -495,7 +495,7 @@ void StochasticScenario::revealData(BPMNOS::number currentTime) const {
     // Process pending disclosures that are due
     for (auto it = disclosures.begin(); it != disclosures.end(); ) {
       auto& [attribute, disclosure] = *it;
-      if (currentTime >= disclosure.effectiveDisclosureTime) {
+      if (currentTime >= disclosure.disclosureTime) {
         // Reveal pre-computed value
         instance.values[attribute] = disclosure.value;
         // Move to past disclosures

--- a/model/data/src/StochasticScenario.cpp
+++ b/model/data/src/StochasticScenario.cpp
@@ -28,11 +28,11 @@ void StochasticScenario::setValue(const BPMNOS::number instanceId, const Attribu
 }
 
 void StochasticScenario::setDisclosure(const BPMNOS::number instanceId, const BPMN::Node* node, BPMNOS::number disclosureTime) {
-  disclosure[(size_t)instanceId][node] = disclosureTime;
+  disclosureTimes[(size_t)instanceId][node] = disclosureTime;
 }
 
 void StochasticScenario::addPendingDisclosure(const BPMNOS::number instanceId, StochasticPendingDisclosure&& pending) {
-  pendingDisclosures[(size_t)instanceId].push_back(std::move(pending));
+  pendingDisclosures[(size_t)instanceId][pending.attribute] = std::move(pending);
 }
 
 void StochasticScenario::addCompletionExpression(const BPMNOS::number instanceId, const BPMN::Node* task, std::shared_ptr<Expression> expression) {
@@ -47,21 +47,37 @@ void StochasticScenario::addDeferredDisclosure(const BPMNOS::number instanceId, 
   deferredDisclosures[(size_t)instanceId].push_back(std::move(deferred));
 }
 
-void StochasticScenario::evaluateDeferredDisclosures() {
+void StochasticScenario::evaluateDeferredDisclosures(BPMNOS::number spawnTime) {
   if (!stochasticHandle || !randomFactory) {
     return;
   }
 
-  for (auto& [instanceId, deferreds] : deferredDisclosures) {
+  // Build map from attribute to deferred for O(1) lookup
+  std::unordered_map<size_t, std::unordered_map<const Attribute*, const DeferredDisclosure*>> deferredByAttribute;
+  for (auto& [instanceId, disclosures] : deferredDisclosures) {
+    for (auto& disclosure : disclosures) {
+      deferredByAttribute[instanceId][disclosure.attribute] = &disclosure;
+    }
+  }
+
+  // Re-evaluate pending disclosures with disclosureTime >= spawnTime
+  for (auto& [instanceId, disclosures] : pendingDisclosures) {
     auto& instance = instances.at(instanceId);
 
-    for (auto& deferred : deferreds) {
+    for (auto& [attribute, pending] : disclosures) {
+      if (pending.disclosureTime < spawnTime) {
+        continue;  // Skip past disclosures
+      }
+
+      // Find corresponding deferred
+      auto* deferred = deferredByAttribute[instanceId][attribute];
+
       // Set RNG context for this (instance, node)
-      auto& rng = getRng(instanceId, deferred.node);
+      auto& rng = getRng(instanceId, deferred->node);
       randomFactory->setCurrentRng(&rng);
 
       // Build status/data vectors from instance values
-      auto extensionElements = deferred.node->extensionElements->as<const ExtensionElements>();
+      auto extensionElements = deferred->node->extensionElements->as<const ExtensionElements>();
       Values status, data;
       for (auto& attr : extensionElements->attributes) {
         status.push_back(instance.values.contains(attr.get()) ? instance.values.at(attr.get()) : std::nullopt);
@@ -70,11 +86,11 @@ void StochasticScenario::evaluateDeferredDisclosures() {
         data.push_back(instance.values.contains(attr.get()) ? instance.values.at(attr.get()) : std::nullopt);
       }
 
-      // Evaluate initialization expression (shared, different results from RNG context)
-      BPMNOS::number value = deferred.initializationExpression->execute(status, data, globals).value_or(0);
+      // Evaluate initialization expression
+      BPMNOS::number value = deferred->initializationExpression->execute(status, data, globals).value_or(0);
 
       // Apply type conversion
-      switch (deferred.attribute->type) {
+      switch (deferred->attribute->type) {
         case ValueType::INTEGER:
           value = BPMNOS::number((int)value);
           break;
@@ -85,42 +101,114 @@ void StochasticScenario::evaluateDeferredDisclosures() {
           break;
       }
 
-      // Store value immediately so subsequent expressions can reference it
-      instance.values[deferred.attribute] = value;
+      // Store value
+      instance.values[deferred->attribute] = value;
 
-      // Update instantiation time if this is the timestamp attribute (ceiled to align with integer time steps)
-      if (deferred.attribute->id == Keyword::Timestamp) {
+      // Update instantiation time if timestamp
+      if (deferred->attribute->id == Keyword::Timestamp) {
         instance.instantiationTime = BPMNOS::number(std::ceil((double)value));
       }
 
-      // Evaluate disclosure expression (shared, different results from RNG context)
-      BPMNOS::number ownDisclosure = BPMNOS::number(std::ceil((double)deferred.disclosureExpression->execute(status, data, globals).value_or(0)));
+      // Evaluate disclosure expression
+      BPMNOS::number ownDisclosure = BPMNOS::number(std::ceil((double)deferred->disclosureExpression->execute(status, data, globals).value_or(0)));
+
       // Compute effective disclosure (max with parent scope)
       BPMNOS::number effectiveDisclosure = ownDisclosure;
-      if (auto childNode = deferred.node->represents<BPMN::ChildNode>()) {
+      if (auto childNode = deferred->node->represents<BPMN::ChildNode>()) {
         auto parentNode = childNode->parent;
-        if (disclosure.contains(instanceId) && disclosure.at(instanceId).contains(parentNode)) {
-          effectiveDisclosure = std::max(effectiveDisclosure, disclosure.at(instanceId).at(parentNode));
+        if (disclosureTimes.contains(instanceId) && disclosureTimes.at(instanceId).contains(parentNode)) {
+          effectiveDisclosure = std::max(effectiveDisclosure, disclosureTimes.at(instanceId).at(parentNode));
         }
       }
 
       // Update node disclosure time
-      if (!disclosure[instanceId].contains(deferred.node)) {
-        disclosure[instanceId][deferred.node] = effectiveDisclosure;
-      } else {
-        disclosure[instanceId][deferred.node] = std::max(disclosure[instanceId][deferred.node], effectiveDisclosure);
+      if (!disclosureTimes[instanceId].contains(deferred->node)) {
+        disclosureTimes[instanceId][deferred->node] = effectiveDisclosure;
+      }
+      else {
+        disclosureTimes[instanceId][deferred->node] = std::max(disclosureTimes[instanceId][deferred->node], effectiveDisclosure);
+      }
+
+      // Update pending disclosure
+      pending = {deferred->attribute, ownDisclosure, effectiveDisclosure, value};
+    }
+  }
+
+  // Initial evaluation: process disclosures not yet in pendingDisclosures
+  for (auto& [instanceId, disclosures] : deferredDisclosures) {
+    auto& instance = instances.at(instanceId);
+
+    for (auto& disclosure : disclosures) {
+      // Skip if already in pendingDisclosures
+      if (pendingDisclosures.contains(instanceId) &&
+          pendingDisclosures.at(instanceId).contains(disclosure.attribute)) {
+        continue;
+      }
+
+      // Set RNG context for this (instance, node)
+      auto& rng = getRng(instanceId, disclosure.node);
+      randomFactory->setCurrentRng(&rng);
+
+      // Build status/data vectors from instance values
+      auto extensionElements = disclosure.node->extensionElements->as<const ExtensionElements>();
+      Values status, data;
+      for (auto& attr : extensionElements->attributes) {
+        status.push_back(instance.values.contains(attr.get()) ? instance.values.at(attr.get()) : std::nullopt);
+      }
+      for (auto& attr : extensionElements->data) {
+        data.push_back(instance.values.contains(attr.get()) ? instance.values.at(attr.get()) : std::nullopt);
+      }
+
+      // Evaluate initialization expression
+      BPMNOS::number value = disclosure.initializationExpression->execute(status, data, globals).value_or(0);
+
+      // Apply type conversion
+      switch (disclosure.attribute->type) {
+        case ValueType::INTEGER:
+          value = BPMNOS::number((int)value);
+          break;
+        case ValueType::BOOLEAN:
+          value = BPMNOS::number(value != 0 ? 1 : 0);
+          break;
+        default:
+          break;
+      }
+
+      // Store value
+      instance.values[disclosure.attribute] = value;
+
+      // Update instantiation time if timestamp
+      if (disclosure.attribute->id == Keyword::Timestamp) {
+        instance.instantiationTime = BPMNOS::number(std::ceil((double)value));
+      }
+
+      // Evaluate disclosure expression
+      BPMNOS::number ownDisclosure = BPMNOS::number(std::ceil((double)disclosure.disclosureExpression->execute(status, data, globals).value_or(0)));
+
+      // Compute effective disclosure (max with parent scope)
+      BPMNOS::number effectiveDisclosure = ownDisclosure;
+      if (auto childNode = disclosure.node->represents<BPMN::ChildNode>()) {
+        auto parentNode = childNode->parent;
+        if (disclosureTimes.contains(instanceId) && disclosureTimes.at(instanceId).contains(parentNode)) {
+          effectiveDisclosure = std::max(effectiveDisclosure, disclosureTimes.at(instanceId).at(parentNode));
+        }
+      }
+
+      // Update node disclosure time
+      if (!disclosureTimes[instanceId].contains(disclosure.node)) {
+        disclosureTimes[instanceId][disclosure.node] = effectiveDisclosure;
+      }
+      else {
+        disclosureTimes[instanceId][disclosure.node] = std::max(disclosureTimes[instanceId][disclosure.node], effectiveDisclosure);
       }
 
       // Add as pending disclosure
-      pendingDisclosures[instanceId].push_back({deferred.attribute, effectiveDisclosure, value});
+      pendingDisclosures[instanceId][disclosure.attribute] = {disclosure.attribute, ownDisclosure, effectiveDisclosure, value};
     }
   }
 
   // Clear RNG context
   randomFactory->setCurrentRng(nullptr);
-
-  // Clear deferred disclosures (they've been processed)
-  deferredDisclosures.clear();
 
   // Compute instantiation bounds now that all disclosures are evaluated
   computeInstantiationBounds();
@@ -134,8 +222,8 @@ void StochasticScenario::computeInstantiationBounds() {
     BPMNOS::number effectiveInstantiation = instance.instantiationTime;
 
     // Check if process has disclosure time (includes both immediate and deferred disclosures)
-    if (disclosure.contains(id) && disclosure.at(id).contains(instance.process)) {
-      effectiveInstantiation = std::max(effectiveInstantiation, disclosure.at(id).at(instance.process));
+    if (disclosureTimes.contains(id) && disclosureTimes.at(id).contains(instance.process)) {
+      effectiveInstantiation = std::max(effectiveInstantiation, disclosureTimes.at(id).at(instance.process));
     }
 
     if (earliestInstantiationTime > effectiveInstantiation) {
@@ -237,8 +325,8 @@ std::vector<const Scenario::InstanceData*> StochasticScenario::getInstances(cons
   for (auto& [id, instance] : instances) {
     // Instance is known when process disclosure time is reached
     BPMNOS::number processDisclosure = 0;
-    if (disclosure.contains(instance.id) && disclosure.at(instance.id).contains(instance.process)) {
-      processDisclosure = disclosure.at(instance.id).at(instance.process);
+    if (disclosureTimes.contains(instance.id) && disclosureTimes.at(instance.id).contains(instance.process)) {
+      processDisclosure = disclosureTimes.at(instance.id).at(instance.process);
     }
     if (currentTime >= processDisclosure) {
       result.push_back(&instance);
@@ -251,8 +339,8 @@ std::vector<std::tuple<const BPMN::Process*, BPMNOS::Values, BPMNOS::Values>> St
   std::vector<std::tuple<const BPMN::Process*, BPMNOS::Values, BPMNOS::Values>> result;
   for (auto& [id, instance] : instances) {
     BPMNOS::number effectiveInstantiationTime = instance.instantiationTime;
-    if (disclosure.contains(instance.id) && disclosure.at(instance.id).contains(instance.process)) {
-      effectiveInstantiationTime = std::max( effectiveInstantiationTime,                                             disclosure.at(instance.id).at(instance.process) );
+    if (disclosureTimes.contains(instance.id) && disclosureTimes.at(instance.id).contains(instance.process)) {
+      effectiveInstantiationTime = std::max( effectiveInstantiationTime,                                             disclosureTimes.at(instance.id).at(instance.process) );
     }
     if (effectiveInstantiationTime == currentTime) {
       auto status = getKnownInitialStatus(&instance, currentTime);
@@ -326,8 +414,8 @@ std::optional<BPMNOS::number> StochasticScenario::getValue(const BPMNOS::number 
 
 std::optional<BPMNOS::Values> StochasticScenario::getStatus(const BPMNOS::number instanceId, const BPMN::Node* node, const BPMNOS::number currentTime) const {
   auto& instance = instances.at((size_t)instanceId);
-  if (disclosure.contains(instance.id) && disclosure.at(instance.id).contains(node)) {
-    if (currentTime < disclosure.at(instance.id).at(node)) {
+  if (disclosureTimes.contains(instance.id) && disclosureTimes.at(instance.id).contains(node)) {
+    if (currentTime < disclosureTimes.at(instance.id).at(node)) {
       return std::nullopt;
     }
   }
@@ -340,8 +428,8 @@ std::optional<BPMNOS::Values> StochasticScenario::getStatus(const BPMNOS::number
 
 std::optional<BPMNOS::Values> StochasticScenario::getData(const BPMNOS::number instanceId, const BPMN::Node* node, const BPMNOS::number currentTime) const {
   auto& instance = instances.at((size_t)instanceId);
-  if (disclosure.contains(instance.id) && disclosure.at(instance.id).contains(node)) {
-    if (currentTime < disclosure.at(instance.id).at(node)) {
+  if (disclosureTimes.contains(instance.id) && disclosureTimes.at(instance.id).contains(node)) {
+    if (currentTime < disclosureTimes.at(instance.id).at(node)) {
       return std::nullopt;
     }
   }
@@ -407,17 +495,18 @@ void StochasticScenario::setTaskCompletionStatus(BPMNOS::number instanceId, cons
 }
 
 void StochasticScenario::revealData(BPMNOS::number currentTime) const {
-  for (auto& [instanceId, pendings] : pendingDisclosures) {
+  for (auto& [instanceId, disclosures] : pendingDisclosures) {
     auto& instance = instances.at(instanceId);
 
     // Process pending disclosures that are due
-    auto it = pendings.begin();
-    while (it != pendings.end()) {
-      if (currentTime >= it->disclosureTime) {
+    for (auto it = disclosures.begin(); it != disclosures.end(); ) {
+      auto& [attribute, disclosure] = *it;
+      if (currentTime >= disclosure.effectiveDisclosureTime) {
         // Reveal pre-computed value
-        instance.values[it->attribute] = it->value;
-        disclosedAttributes.insert({instanceId, it->attribute});
-        it = pendings.erase(it);
+        instance.values[attribute] = disclosure.value;
+        // Move to past disclosures
+        pastDisclosures[instanceId][attribute] = std::move(disclosure);
+        it = disclosures.erase(it);
       }
       else {
         ++it;
@@ -430,8 +519,8 @@ std::optional<BPMNOS::Values> StochasticScenario::getActivityReadyStatus(BPMNOS:
   size_t id = (size_t)instanceId;
 
   // Check if node data is disclosed
-  if (disclosure.contains(id) && disclosure.at(id).contains(activity)) {
-    if (currentTime < disclosure.at(id).at(activity)) {
+  if (disclosureTimes.contains(id) && disclosureTimes.at(id).contains(activity)) {
+    if (currentTime < disclosureTimes.at(id).at(activity)) {
       return std::nullopt;
     }
   }

--- a/model/data/src/StochasticScenario.h
+++ b/model/data/src/StochasticScenario.h
@@ -27,13 +27,14 @@ struct StochasticPendingDisclosure {
 /**
  * @brief Structure representing a deferred disclosure.
  *
- * Stores expression strings to be evaluated per-scenario for independent sampling.
+ * Stores shared expressions to be evaluated per-scenario for independent sampling.
+ * Expression objects are immutable; different results come from different RNG contexts.
  */
 struct DeferredDisclosure {
-  const Attribute* attribute;           ///< The attribute to initialize
-  const BPMN::Node* node;               ///< The node scope
-  std::string initializationExpression; ///< Expression to compute value
-  std::string disclosureExpression;     ///< Expression to compute disclosure time
+  const Attribute* attribute;                    ///< The attribute to initialize
+  const BPMN::Node* node;                        ///< The node scope
+  std::shared_ptr<Expression> initializationExpression;  ///< Expression to compute value
+  std::shared_ptr<Expression> disclosureExpression;      ///< Expression to compute disclosure time
 };
 
 /**
@@ -106,8 +107,8 @@ protected:
   void setValue(const BPMNOS::number instanceId, const Attribute* attribute, std::optional<BPMNOS::number> value);
   void setDisclosure(const BPMNOS::number instanceId, const BPMN::Node* node, BPMNOS::number disclosureTime);
   void addPendingDisclosure(const BPMNOS::number instanceId, StochasticPendingDisclosure&& pending);
-  void addCompletionExpression(const BPMNOS::number instanceId, const BPMN::Node* task, std::unique_ptr<Expression> expression);
-  void addReadyExpression(const BPMNOS::number instanceId, const BPMN::Node* node, std::unique_ptr<Expression> expression);
+  void addCompletionExpression(const BPMNOS::number instanceId, const BPMN::Node* task, std::shared_ptr<Expression> expression);
+  void addReadyExpression(const BPMNOS::number instanceId, const BPMN::Node* node, std::shared_ptr<Expression> expression);
   void addDeferredDisclosure(const BPMNOS::number instanceId, DeferredDisclosure&& deferred);
 
   /// Evaluate all deferred disclosures using scenario-specific RNG
@@ -121,11 +122,11 @@ protected:
   mutable std::unordered_map<size_t, std::vector<StochasticPendingDisclosure>> pendingDisclosures; ///< Instance ID -> pending disclosures
   mutable std::set<std::pair<size_t, const Attribute*>> disclosedAttributes; ///< Track which attributes have been disclosed
 
-  /// Ready expressions per (instance, node)
-  std::unordered_map<size_t, std::unordered_map<const BPMN::Node*, std::vector<std::unique_ptr<Expression>>>> readyExpressions;
+  /// Ready expressions per (instance, node) - shared across scenario copies
+  std::unordered_map<size_t, std::unordered_map<const BPMN::Node*, std::vector<std::shared_ptr<Expression>>>> readyExpressions;
 
-  /// Completion expressions per (instance, node)
-  std::unordered_map<size_t, std::unordered_map<const BPMN::Node*, std::vector<std::unique_ptr<Expression>>>> completionExpressions;
+  /// Completion expressions per (instance, node) - shared across scenario copies
+  std::unordered_map<size_t, std::unordered_map<const BPMN::Node*, std::vector<std::shared_ptr<Expression>>>> completionExpressions;
 
   /// Deferred disclosures per instance (evaluated per-scenario)
   std::unordered_map<size_t, std::vector<DeferredDisclosure>> deferredDisclosures;

--- a/model/data/src/StochasticScenario.h
+++ b/model/data/src/StochasticScenario.h
@@ -76,6 +76,21 @@ public:
     unsigned int seed = 0
   );
 
+  /**
+   * @brief Copy constructor that resamples future values.
+   *
+   * Copies all data from original. Values with disclosure time >= spawnTime are
+   * re-evaluated using the new seed. The new seed is appended to scenarioSeeds.
+   *
+   * @pre spawnTime must be smaller or equal to all pending disclosure times.
+   *      Throws std::runtime_error if any pending disclosure has disclosureTime < spawnTime.
+   *
+   * @param original The scenario to copy from
+   * @param spawnTime Values with disclosure time >= spawnTime are resampled
+   * @param seed New seed for resampling future values
+   */
+  StochasticScenario(StochasticScenario* original, BPMNOS::number spawnTime, unsigned int seed);
+
   BPMNOS::number getEarliestInstantiationTime() const override;
   bool isCompleted(const BPMNOS::number currentTime) const override;
 
@@ -143,6 +158,7 @@ protected:
    * maxResamplingTries times, falling back to spawnTime if still in the past.
    *
    * @param spawnTime Items with disclosure time < spawnTime are not evaluated again
+   * @throws std::logic_error if any pending disclosure has disclosureTime < spawnTime
    */
   void evaluateDeferredDisclosures(BPMNOS::number spawnTime = std::numeric_limits<BPMNOS::number>::lowest());
 

--- a/model/data/src/StochasticScenario.h
+++ b/model/data/src/StochasticScenario.h
@@ -44,6 +44,19 @@ struct DeferredDisclosure {
  * - Random functions in INITIALIZATION, DISCLOSURE, and COMPLETION expressions
  * - Per (instance, node) RNG for reproducibility
  * - Downward compatible with static (3-column) and dynamic (4-column) CSV formats
+ * - Scenario copying with resampling of future values
+ *
+ * @par Resampling Behavior
+ * When a scenario is copied at a given spawnTime, values with disclosure time >= spawnTime
+ * are re-evaluated using a new RNG seed. If re-evaluated timestamps or disclosure times
+ * fall before spawnTime, they are resampled up to @ref maxResamplingTries times. If still
+ * in the past after all attempts, they fall back to spawnTime.
+ *
+ * @warning Resampling with fallback may alter the effective probability distribution,
+ *          creating a point mass at spawnTime.
+ *
+ * @par Assumptions
+ * - CSV rows must be ordered with parent nodes before child nodes for dependent expressions
  */
 class StochasticDataProvider;
 
@@ -51,6 +64,11 @@ class StochasticScenario : public Scenario {
   friend class StochasticDataProvider;
 
 public:
+  /**
+   * @brief Maximum number of resampling attempts when re-evaluated disclosure time is before spawnTime
+   */
+  static constexpr int maxResamplingTries = 4;
+
   StochasticScenario(
     const Model* model,
     const std::unordered_map<const Attribute*, BPMNOS::number>& globalValueMap,
@@ -89,6 +107,12 @@ public:
    */
   void noticeCompletionPending(BPMNOS::number instanceId, const BPMN::Node* task, const Values& status, const SharedValues& data,     const Values& globals) const override;
 
+  /**
+   * @brief House keeping of internal data.
+   *
+   * This method only does house keeping without actually revealing data.
+   * Disclosures of data are handled by checking node-level disclosureTimes.
+   */
   void revealData(BPMNOS::number currentTime) const;
 
 private:
@@ -111,7 +135,14 @@ protected:
   void addReadyExpression(const BPMNOS::number instanceId, const BPMN::Node* node, std::shared_ptr<Expression> expression);
   void addDeferredDisclosure(const BPMNOS::number instanceId, DeferredDisclosure&& deferred);
 
-  /// (Re-)evaluates items with disclosure time >= spawnTime
+  /**
+   * @brief (Re-)evaluates deferred disclosures with disclosure time >= spawnTime.
+   *
+   * Timestamps and disclosure times that fall before spawnTime are resampled up to
+   * maxResamplingTries times, falling back to spawnTime if still in the past.
+   *
+   * @param spawnTime Items with disclosure time < spawnTime are not evaluated again
+   */
   void evaluateDeferredDisclosures(BPMNOS::number spawnTime = std::numeric_limits<BPMNOS::number>::lowest());
 
   /// Get or create RNG for (instance, node) pair

--- a/model/data/src/StochasticScenario.h
+++ b/model/data/src/StochasticScenario.h
@@ -21,7 +21,6 @@ namespace BPMNOS::Model {
 struct StochasticPendingDisclosure {
   const Attribute* attribute;              ///< The attribute to initialize
   BPMNOS::number disclosureTime;           ///< Own disclosure time (from expression)
-  BPMNOS::number effectiveDisclosureTime;  ///< Effective disclosure time (max with parent)
   BPMNOS::number value;                    ///< Pre-computed value to reveal at disclosure time
 };
 

--- a/model/data/src/StochasticScenario.h
+++ b/model/data/src/StochasticScenario.h
@@ -19,9 +19,10 @@ namespace BPMNOS::Model {
  * The value is computed at parse time using only global attributes.
  */
 struct StochasticPendingDisclosure {
-  const Attribute* attribute;     ///< The attribute to initialize
-  BPMNOS::number disclosureTime;  ///< Time when this attribute is disclosed
-  BPMNOS::number value;           ///< Pre-computed value to reveal at disclosure time
+  const Attribute* attribute;              ///< The attribute to initialize
+  BPMNOS::number disclosureTime;           ///< Own disclosure time (from expression)
+  BPMNOS::number effectiveDisclosureTime;  ///< Effective disclosure time (max with parent)
+  BPMNOS::number value;                    ///< Pre-computed value to reveal at disclosure time
 };
 
 /**
@@ -111,16 +112,16 @@ protected:
   void addReadyExpression(const BPMNOS::number instanceId, const BPMN::Node* node, std::shared_ptr<Expression> expression);
   void addDeferredDisclosure(const BPMNOS::number instanceId, DeferredDisclosure&& deferred);
 
-  /// Evaluate all deferred disclosures using scenario-specific RNG
-  void evaluateDeferredDisclosures();
+  /// (Re-)evaluates items with disclosure time >= spawnTime
+  void evaluateDeferredDisclosures(BPMNOS::number spawnTime = std::numeric_limits<BPMNOS::number>::lowest());
 
   /// Get or create RNG for (instance, node) pair
   std::mt19937& getRng(size_t instanceId, const BPMN::Node* node) const;
 
   mutable std::unordered_map<size_t, InstanceData> instances;
-  std::unordered_map<size_t, std::unordered_map<const BPMN::Node*, BPMNOS::number>> disclosure; ///< Instance ID -> Node -> disclosure time
-  mutable std::unordered_map<size_t, std::vector<StochasticPendingDisclosure>> pendingDisclosures; ///< Instance ID -> pending disclosures
-  mutable std::set<std::pair<size_t, const Attribute*>> disclosedAttributes; ///< Track which attributes have been disclosed
+  std::unordered_map<size_t, std::unordered_map<const BPMN::Node*, BPMNOS::number>> disclosureTimes; ///< Instance ID -> Node -> disclosure time
+  mutable std::unordered_map<size_t, std::unordered_map<const Attribute*, StochasticPendingDisclosure>> pastDisclosures; ///< Already disclosed
+  mutable std::unordered_map<size_t, std::unordered_map<const Attribute*, StochasticPendingDisclosure>> pendingDisclosures; ///< Not yet disclosed
 
   /// Ready expressions per (instance, node) - shared across scenario copies
   std::unordered_map<size_t, std::unordered_map<const BPMN::Node*, std::vector<std::shared_ptr<Expression>>>> readyExpressions;

--- a/model/data/src/StochasticScenario.h
+++ b/model/data/src/StochasticScenario.h
@@ -5,6 +5,7 @@
 #include "Scenario.h"
 #include "model/bpmnos/src/extensionElements/Expression.h"
 #include "model/utility/src/RandomDistributionFactory.h"
+#include <list>
 #include <memory>
 #include <random>
 #include <set>
@@ -165,7 +166,8 @@ protected:
   /// Per (instance, node) RNG for reproducibility
   mutable std::map<std::pair<size_t, const BPMN::Node*>, std::mt19937> rngs;
 
-  unsigned int scenarioSeed;
+  /// Seed history: list of (spawnTime, seed) pairs for scenario copies
+  std::list<std::pair<BPMNOS::number, unsigned int>> scenarioSeeds;
   BPMNOS::number earliestInstantiationTime;
   BPMNOS::number latestInstantiationTime;
 

--- a/tests/data/stochastic/test.h
+++ b/tests/data/stochastic/test.h
@@ -307,3 +307,115 @@ SCENARIO( "Stochastic data provider", "[data][stochastic]" ) {
   }
 
 }
+
+SCENARIO( "Stochastic scenario copy constructor", "[data][stochastic][copy]" ) {
+  const std::string modelFile = "tests/data/stochastic/Executable_process.bpmn";
+  REQUIRE_NOTHROW( Model::Model(modelFile) );
+
+  GIVEN( "An instance with future disclosures" ) {
+    std::string csv =
+      "INSTANCE_ID; NODE_ID; INITIALIZATION; DISCLOSURE; READY; COMPLETION\n"
+      "Instance_1; Process_1; timestamp := uniform(0,10); 0;;\n"
+      "Instance_1; Process_1; x := uniform(0,1000); 5;;\n"
+      "Instance_1; Activity_1; y := uniform(0,1000); 15;;\n"
+    ;
+
+    WHEN( "The scenario is copied after disclosure of x" ) {
+      Model::StochasticDataProvider dataProvider(modelFile, csv, 42);
+      auto scenario = dataProvider.createScenario(0);
+      auto* stochasticScenario = dynamic_cast<Model::StochasticScenario*>(scenario.get());
+      REQUIRE( stochasticScenario != nullptr );
+
+      // Reveal data up to time 10
+      stochasticScenario->revealData(10);
+
+      // Get original values
+      auto instances = scenario->getInstances(10);
+      REQUIRE( instances.size() == 1 );
+      auto instance = instances[0];
+      auto originalTimestamp = scenario->getValue(instance->id,
+        dataProvider.getModel().processes[0]->extensionElements->as<Model::ExtensionElements>()->attributes[0].get(), 10);
+      auto originalX = scenario->getValue(instance->id,
+        dataProvider.getModel().processes[0]->extensionElements->as<Model::ExtensionElements>()->attributes[1].get(), 10);
+
+      // Copy at spawnTime = 11 with new seed
+      Model::StochasticScenario copiedScenario(stochasticScenario, 11, 999);
+
+      THEN( "Past values (timestamp, x) are preserved" ) {
+        auto copiedInstances = copiedScenario.getInstances(10);
+        REQUIRE( copiedInstances.size() == 1 );
+        auto copiedInstance = copiedInstances[0];
+
+        auto copiedTimestamp = copiedScenario.getValue(copiedInstance->id,
+          dataProvider.getModel().processes[0]->extensionElements->as<Model::ExtensionElements>()->attributes[0].get(), 10);
+        auto copiedX = copiedScenario.getValue(copiedInstance->id,
+          dataProvider.getModel().processes[0]->extensionElements->as<Model::ExtensionElements>()->attributes[1].get(), 10);
+
+        REQUIRE( originalTimestamp.has_value() );
+        REQUIRE( copiedTimestamp.has_value() );
+        REQUIRE( originalTimestamp.value() == copiedTimestamp.value() );
+
+        REQUIRE( originalX.has_value() );
+        REQUIRE( copiedX.has_value() );
+        REQUIRE( originalX.value() == copiedX.value() );
+      }
+
+      THEN( "Future values (y) are resampled" ) {
+        // y has disclosure time 15, so it should be resampled
+        auto& process = dataProvider.getModel().processes[0];
+        auto activity = process->find([](BPMN::Node* n) { return n->id == "Activity_1"; });
+        REQUIRE( activity != nullptr );
+
+        // Get y from original at time 15
+        auto originalY = scenario->getStatus(instance->id, activity, 15);
+        REQUIRE( originalY.has_value() );
+
+        // Keep copying with different seeds until we get a different value
+        unsigned int seed = 1;
+        bool foundDifferent = false;
+        while (!foundDifferent && seed < 1000) {
+          Model::StochasticScenario testCopy(stochasticScenario, 11, seed);
+          auto copiedY = testCopy.getStatus(instance->id, activity, 15);
+          REQUIRE( copiedY.has_value() );
+          if (originalY->at(0).value() != copiedY->at(0).value()) {
+            foundDifferent = true;
+          }
+          ++seed;
+        }
+        REQUIRE( foundDifferent );
+      }
+    }
+  }
+
+  GIVEN( "An instance with all disclosures in the past" ) {
+    std::string csv =
+      "INSTANCE_ID; NODE_ID; INITIALIZATION; DISCLOSURE; READY; COMPLETION\n"
+      "Instance_1; Process_1; timestamp := 0; 0;;\n"
+      "Instance_1; Process_1; x := 42; 0;;\n"
+    ;
+
+    WHEN( "The scenario is copied" ) {
+      Model::StochasticDataProvider dataProvider(modelFile, csv, 42);
+      auto scenario = dataProvider.createScenario(0);
+      auto* stochasticScenario = dynamic_cast<Model::StochasticScenario*>(scenario.get());
+
+      // Reveal all data
+      stochasticScenario->revealData(10);
+
+      // Copy at spawnTime = 11
+      Model::StochasticScenario copiedScenario(stochasticScenario, 11, 999);
+
+      THEN( "All values are preserved" ) {
+        auto copiedInstances = copiedScenario.getInstances(0);
+        REQUIRE( copiedInstances.size() == 1 );
+        auto copiedInstance = copiedInstances[0];
+
+        auto copiedX = copiedScenario.getValue(copiedInstance->id,
+          dataProvider.getModel().processes[0]->extensionElements->as<Model::ExtensionElements>()->attributes[1].get(), 0);
+        REQUIRE( copiedX.has_value() );
+        REQUIRE( copiedX.value() == 42 );
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Add `StochasticScenario(StochasticScenario* original, BPMNOS::number spawnTime, unsigned int seed)` copy constructor with resampling

  - Add copy constructor that preserves past values and resamples future
    disclosures (disclosureTime >= spawnTime) using a new RNG seed
  - Change `scenarioSeed` to `scenarioSeeds` list to track seed history
  - Update `evaluateDeferredDisclosures` to skip `pastDisclosures` and validate
    preconditions (throws std::logic_error on violations)
   - Add tests for copy constructor behavior

**Fix:** Accept numbers in `StochasticDataProvider` DISCLOSURE column
